### PR TITLE
add ObjectType to the description field of ScanInfo

### DIFF
--- a/src/main/java/org/openmucextensions/driver/bacnet/BACnetConnection.java
+++ b/src/main/java/org/openmucextensions/driver/bacnet/BACnetConnection.java
@@ -118,19 +118,28 @@ public class BACnetConnection implements Connection, DeviceEventListener {
 		LOCAL_DEVICE = localDevice;
 		REMOTE_DEVICE = remoteDevice;
 		
-		// accepted object types (only this object types will be provided as channel to the OpenMUC framework)
-		// the related ObjectTypeInfo class specifies the OpenMUC behavior
-		acceptedTypes = new HashMap<ObjectType, ObjectTypeInfo>();
-		// analog objects are of type REAL in BACnet (32 bit, float)
-		acceptedTypes.put(ObjectType.analogInput, new ObjectTypeInfo(ValueType.FLOAT, null, Boolean.TRUE, Boolean.FALSE));
-		acceptedTypes.put(ObjectType.analogOutput, new ObjectTypeInfo(ValueType.FLOAT, null, Boolean.TRUE, Boolean.TRUE));
-		acceptedTypes.put(ObjectType.analogValue, new ObjectTypeInfo(ValueType.FLOAT, null, Boolean.TRUE, Boolean.TRUE));
-		acceptedTypes.put(ObjectType.binaryInput, new ObjectTypeInfo(ValueType.BOOLEAN, null, Boolean.TRUE, Boolean.FALSE));
-		acceptedTypes.put(ObjectType.binaryOutput, new ObjectTypeInfo(ValueType.BOOLEAN, null, Boolean.TRUE, Boolean.TRUE));
-		acceptedTypes.put(ObjectType.binaryValue, new ObjectTypeInfo(ValueType.BOOLEAN, null, Boolean.TRUE, Boolean.TRUE));
-		acceptedTypes.put(ObjectType.multiStateInput, new ObjectTypeInfo(ValueType.INTEGER, null, Boolean.TRUE, Boolean.FALSE));
-		acceptedTypes.put(ObjectType.multiStateOutput, new ObjectTypeInfo(ValueType.INTEGER, null, Boolean.TRUE, Boolean.TRUE));
-		acceptedTypes.put(ObjectType.multiStateValue, new ObjectTypeInfo(ValueType.INTEGER, null, Boolean.TRUE, Boolean.TRUE));
+		 // accepted object types (only this object types will be provided as channel to the OpenMUC framework)
+        // the related ObjectTypeInfo class specifies the OpenMUC behavior
+        acceptedTypes = new HashMap<ObjectType, ObjectTypeInfo>();
+        // analog objects are of type REAL in BACnet (32 bit, float)
+        acceptedTypes.put(ObjectType.analogInput,
+                new ObjectTypeInfo(ValueType.FLOAT, null, Boolean.TRUE, Boolean.FALSE, ObjectType.analogInput));
+        acceptedTypes.put(ObjectType.analogOutput,
+                new ObjectTypeInfo(ValueType.FLOAT, null, Boolean.TRUE, Boolean.TRUE, ObjectType.analogOutput));
+        acceptedTypes.put(ObjectType.analogValue,
+                new ObjectTypeInfo(ValueType.FLOAT, null, Boolean.TRUE, Boolean.TRUE, ObjectType.analogValue));
+        acceptedTypes.put(ObjectType.binaryInput,
+                new ObjectTypeInfo(ValueType.BOOLEAN, null, Boolean.TRUE, Boolean.FALSE, ObjectType.binaryInput));
+        acceptedTypes.put(ObjectType.binaryOutput,
+                new ObjectTypeInfo(ValueType.BOOLEAN, null, Boolean.TRUE, Boolean.TRUE, ObjectType.binaryOutput));
+        acceptedTypes.put(ObjectType.binaryValue,
+                new ObjectTypeInfo(ValueType.BOOLEAN, null, Boolean.TRUE, Boolean.TRUE, ObjectType.binaryValue));
+        acceptedTypes.put(ObjectType.multiStateInput,
+                new ObjectTypeInfo(ValueType.INTEGER, null, Boolean.TRUE, Boolean.FALSE, ObjectType.multiStateInput));
+        acceptedTypes.put(ObjectType.multiStateOutput,
+                new ObjectTypeInfo(ValueType.INTEGER, null, Boolean.TRUE, Boolean.TRUE, ObjectType.multiStateOutput));
+        acceptedTypes.put(ObjectType.multiStateValue,
+                new ObjectTypeInfo(ValueType.INTEGER, null, Boolean.TRUE, Boolean.TRUE, ObjectType.multiStateValue));
 	
 		LOCAL_DEVICE.getEventHandler().addListener(this);
 	}

--- a/src/main/java/org/openmucextensions/driver/bacnet/ObjectTypeInfo.java
+++ b/src/main/java/org/openmucextensions/driver/bacnet/ObjectTypeInfo.java
@@ -19,6 +19,8 @@ package org.openmucextensions.driver.bacnet;
 import org.openmuc.framework.config.ChannelScanInfo;
 import org.openmuc.framework.data.ValueType;
 
+import com.serotonin.bacnet4j.type.enumerated.ObjectType;
+
 /**
  * This class stores object type information for converting BACnet objects to OpenMUC types.
  * 
@@ -27,20 +29,22 @@ import org.openmuc.framework.data.ValueType;
  */
 public class ObjectTypeInfo {
 	
-	private final ValueType valueType;		// OpenMUC value type
-	private final Integer valueTypeLength;	// OpenMUC value length (for strings or arrays, null otherwise)
-	private final Boolean readable;			// is object readable
-	private final Boolean writable;			// is object writeable
+	 private final ValueType valueType; // OpenMUC value type
+	 private final Integer valueTypeLength; // OpenMUC value length (for strings or arrays, null otherwise)
+	 private final Boolean readable; // is object readable
+	 private final Boolean writable; // is object writeable
+	 private final ObjectType objectType;
+
+	 public ObjectTypeInfo(ValueType valueType, Integer valueTypeLength, Boolean readable, Boolean writable, ObjectType objecttyp) {
+	    this.valueType = valueType;
+	    this.valueTypeLength = valueTypeLength;
+	    this.readable = readable;
+	    this.writable = writable;
+	    this.objectType = objecttyp;
+	 }
 	
-	public ObjectTypeInfo(ValueType valueType, Integer valueTypeLength, Boolean readable, Boolean writable) {
-		this.valueType = valueType;
-		this.valueTypeLength = valueTypeLength;
-		this.readable = readable;
-		this.writable = writable;
-	}
-	
-	public ChannelScanInfo getChannelScanInfo(String address, String description) {	
-		return new ChannelScanInfo(address, description, valueType, valueTypeLength, readable, writable);
-	}
+	 public ChannelScanInfo getChannelScanInfo(String address, String description) {	
+		return new ChannelScanInfo(address, description + ";" + objectType.toString(), valueType, valueTypeLength, readable, writable);
+	 }
 	
 }


### PR DESCRIPTION
This way the object type information is easily added to the description of a channel so that an app can use this meta information
